### PR TITLE
Fix a problem that changed flag is turned on when only open session and do nothing.

### DIFF
--- a/modules/juce_events/broadcasters/juce_AsyncUpdater.h
+++ b/modules/juce_events/broadcasters/juce_AsyncUpdater.h
@@ -64,6 +64,10 @@ public:
     */
     void triggerAsyncUpdate();
 
+    #if JUCE_MAC
+    void triggerAsyncUpdatePriority (MessagePriority);
+    #endif
+
     /** This will stop any pending updates from happening.
 
         If called after triggerAsyncUpdate() and before the handleAsyncUpdate()
@@ -105,6 +109,8 @@ private:
     ReferenceCountedObjectPtr<AsyncUpdaterMessage> activeMessage;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (AsyncUpdater)
+
+    void triggerAsyncUpdatePost (std::function<bool()> post);
 };
 
 } // namespace juce

--- a/modules/juce_events/messages/juce_MessageManager.h
+++ b/modules/juce_events/messages/juce_MessageManager.h
@@ -32,6 +32,15 @@ class ActionBroadcaster;
 /** See MessageManager::callFunctionOnMessageThread() for use of this function type. */
 using MessageCallbackFunction = void* (void* userData);
 
+//==============================================================================
+/** An enumeration that express a priority of a message. */
+#if JUCE_MAC || JUCE_IOS
+enum class MessagePriority
+{
+    normal = 0,
+    low = 1
+};
+#endif
 
 //==============================================================================
 /**
@@ -185,7 +194,12 @@ public:
         ~MessageBase() override = default;
 
         virtual void messageCallback() = 0;
+
+        #if JUCE_MAC
+        bool post (MessagePriority priority = MessagePriority::normal);
+        #else
         bool post();
+        #endif
 
         using Ptr = ReferenceCountedObjectPtr<MessageBase>;
 
@@ -329,7 +343,11 @@ private:
     Thread::ThreadID messageThreadId;
     Atomic<Thread::ThreadID> threadWithLock;
 
+    #if JUCE_MAC
+    static bool postMessageToSystemQueue (MessageBase*, MessagePriority);
+    #else
     static bool postMessageToSystemQueue (MessageBase*);
+    #endif
     static void* exitModalLoopCallback (void*);
     static void doPlatformSpecificInitialisation();
     static void doPlatformSpecificShutdown();

--- a/modules/juce_events/native/juce_mac_MessageManager.mm
+++ b/modules/juce_events/native/juce_mac_MessageManager.mm
@@ -451,10 +451,10 @@ void MessageManager::doPlatformSpecificShutdown()
     appDelegate = nullptr;
 }
 
-bool MessageManager::postMessageToSystemQueue (MessageBase* message)
+bool MessageManager::postMessageToSystemQueue (MessageBase* message, MessagePriority priority)
 {
     jassert (appDelegate != nil);
-    appDelegate->messageQueue.post (message);
+    appDelegate->messageQueue.post (message, priority);
     return true;
 }
 
@@ -487,7 +487,6 @@ void __attribute__ ((visibility("default"))) repostCurrentNSEvent()
 
     (new EventReposter())->post();
 }
-
 
 //==============================================================================
 #if JUCE_MAC


### PR DESCRIPTION
One way to solve a problem that described https://github.com/kushview/Element/issues/465, I tried to implement a low priority system message queue.

By using this queue, in opening a session process, the processing of the `resetChanges` message can be delayed until later than other messages posted in the opening process. the low priority message queue is used only when the normal priority (original) message queue is empty at every message loop phase.

## Alternative way

The way described above is complexly. The problem is occurred when a component's ports state is changed, even if user doesn't perform any operation. Then, it might be a good idea to set `changedSinceSave` flag only when Elements is operated by user interactively. I think that when a component's  ports changed for some reason, user should fix the effects manually if it makes some problem.
